### PR TITLE
Add GitHub Actions schema

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+on: [push, pull_request]
+name: Checks
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Restore cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+          ~/Library/Caches/go-build
+          %LocalAppData%\go-build
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Fetch Go version from mod file
+      run: echo "GO_VERSION=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}
+    - name: Test (Windows)
+      if: matrix.os == 'windows-latest'
+      run: go version # Nothing to test yet.
+    - name: Test (*nix)
+      if: matrix.os != 'windows-latest'
+      run: |
+        # The CI has an old version of Go by default.
+        # setup-go installs the version we want, but
+        # root won't have that binary in its `PATH`.
+        export GO_USER_BIN="$(which go)"
+        #sudo -E ${GO_USER_BIN} test -v ./...


### PR DESCRIPTION
I'm not familiar with GitHub actions yet so any suggestions are welcome.

This works for the platforms specified, but could probably be better.
The version of Go used is pulled from the go.mod header which is used with `actions/setup-go`.
Not sure if using `GITHUB_ENV` is preferable to action `outputs` or even something else.

I think the directories being cached should probably be platform dependent so we're not storing and restoring everything. 
But I don't know how to better split that up yet.

The non-Windows tests need root privileges to install and control the service. But sudo's $PATH doesn't see the Go installed from `setup-go`, (it calls the CI's preinstalled Go instead) even with `-E` it seems `$PATH` is protected. 
As a workaround we find the path and call it manually.
If there's a better way, we should do that instead. This feels like the wrong way to do it.
It may also be worth separating tests that need privileges from those that don't.

Note that while the test schema should work, the service tests themselves on Linux are going to need an upstream patch to the "service" pkg they depend on.