### PR TITLE
ci: remove special handling for FUSE-T

### DIFF
--- a/.github/actions/setup/fuse-t/action.yaml
+++ b/.github/actions/setup/fuse-t/action.yaml
@@ -7,7 +7,3 @@ runs:
       run: |
         brew tap macos-fuse-t/homebrew-cask
         brew install fuse-t
-
-        sudo mkdir /usr/local/include/osxfuse
-        sudo ln -s /usr/local/include/fuse /usr/local/include/osxfuse/fuse
-        sudo ln -s /usr/local/lib/libfuse-t.dylib /usr/local/lib/libosxfuse.2.dylib

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -3,7 +3,6 @@ description: "Runs the standard Golang test suite"
 runs:
   using: "composite"
   steps:
-    - uses: ./.github/actions/setup
     - if: runner.os == 'Windows'
       shell: pwsh
       run: |

--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup
       - uses: ./.github/actions/test
   Build:
     if: github.ref == 'refs/tags/prerelease' ||  github.ref == 'refs/tags/release'

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.6.0
 	github.com/multiformats/go-multiaddr-dns v0.3.1
 	github.com/u-root/uio v0.0.0-20220204230159-dac05f7d2cb4
-	github.com/winfsp/cgofuse v1.5.1-0.20221106144041-c23bd0f99a49
+	github.com/winfsp/cgofuse v1.5.1-0.20221118130120-84c0898ad2e0
 	golang.org/x/exp v0.0.0-20220921023135-46d9e7742f1e
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1023,8 +1023,8 @@ github.com/whyrusleeping/mafmt v1.2.8/go.mod h1:faQJFPbLSxzD9xpA02ttW/tS9vZykNvX
 github.com/whyrusleeping/mdns v0.0.0-20180901202407-ef14215e6b30/go.mod h1:j4l84WPFclQPj320J9gp0XwNKBb3U0zt5CBqjPp22G4=
 github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9/go.mod h1:j4l84WPFclQPj320J9gp0XwNKBb3U0zt5CBqjPp22G4=
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7/go.mod h1:X2c0RVCI1eSUFI8eLcY3c0423ykwiUdxLJtkDvruhjI=
-github.com/winfsp/cgofuse v1.5.1-0.20221106144041-c23bd0f99a49 h1:+kD4nvjSbuESNeVUdkrppns7qRJNKSrWBWjrg9o3TV8=
-github.com/winfsp/cgofuse v1.5.1-0.20221106144041-c23bd0f99a49/go.mod h1:uxjoF2jEYT3+x+vC2KJddEGdk/LU8pRowXmyVMHSV5I=
+github.com/winfsp/cgofuse v1.5.1-0.20221118130120-84c0898ad2e0 h1:j3un8DqYvvAOqKI5OPz+/RRVhDFipbPKI4t2Uk5RBJw=
+github.com/winfsp/cgofuse v1.5.1-0.20221118130120-84c0898ad2e0/go.mod h1:uxjoF2jEYT3+x+vC2KJddEGdk/LU8pRowXmyVMHSV5I=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=


### PR DESCRIPTION
We no longer have to impersonate macFUSE after cgofuse@c23bd0f99a49f318f12e12d50cd8f0cd611a56f8.
This PR is just to trigger the CI / validate this actually works as it did offline.