### PR TITLE
Don't convert IPFS pins' CIDs

### DIFF
--- a/internal/filesystem/ipfspins.go
+++ b/internal/filesystem/ipfspins.go
@@ -194,20 +194,11 @@ func (pd *pinsDirectory) Close() error {
 }
 
 func (pe *pinDirEntry) Name() string {
-	pinCid := pe.Pin.Path().Cid()
-	if pinCid.Version() == 0 {
-		pinCid = upgradeCid(pinCid)
-	}
-	return pinCid.String()
-	// return path.Base(pe.Pin.Path().String())
+	return pe.Pin.Path().Cid().String()
 }
 
 func (pe *pinDirEntry) Info() (fs.FileInfo, error) {
 	pinCid := pe.Pin.Path().Cid()
-	if pinCid.Version() == 0 {
-		pinCid = upgradeCid(pinCid)
-	}
-
 	if ipfs := pe.ipfs; ipfs != nil {
 		return fs.Stat(pe.ipfs, pinCid.String())
 	}

--- a/internal/filesystem/ipfsutil.go
+++ b/internal/filesystem/ipfsutil.go
@@ -43,23 +43,6 @@ func goToIPFSCore(fsid ID, goPath string) corepath.Path {
 		rootCID, rootCID, ""),
 		pathComponents[1:]...,
 	)
-
-	/*
-		newRoot := gopath.Path(path.Join(
-			"/",
-			strings.ToLower(fsid.String()), // "ipfs", "ipns", ...
-			rootCID.String(),
-		))
-		return corepath.Join(newRoot, pathComponents[1:]...)
-	*/
-	/*
-		return corepath.New(
-			path.Join("/",
-				strings.ToLower(fsid.String()), // "ipfs", "ipns", ...
-				goPath,
-			),
-		)
-	*/
 }
 
 func statNode(name string, modtime time.Time, permissions fs.FileMode,

--- a/internal/filesystem/ipfsutil.go
+++ b/internal/filesystem/ipfsutil.go
@@ -27,21 +27,14 @@ func goToIPFSCore(fsid ID, goPath string) corepath.Path {
 	var (
 		pathComponents = strings.Split(goPath, "/")
 		cidStr         = pathComponents[0]
+		rootCID, err   = cid.Decode(cidStr)
 	)
-	rootCID, err := cid.Decode(cidStr)
 	if err != nil {
 		return dbgErrPath(err)
 	}
-
 	pathPrefix := path.Join("/",
 		strings.ToLower(fsid.String()), // "ipfs", "ipns", ...
 	)
-
-	if rootCID.Version() >= 1 {
-		return corepath.New(path.Join(pathPrefix, goPath))
-	}
-
-	rootCID = upgradeCid(rootCID)
 	return corepath.Join(corepath.NewResolvedPath(
 		gopath.Path(path.Join(
 			pathPrefix,
@@ -68,8 +61,6 @@ func goToIPFSCore(fsid ID, goPath string) corepath.Path {
 		)
 	*/
 }
-
-func upgradeCid(c cid.Cid) cid.Cid { return cid.NewCidV1(c.Type(), c.Hash()) }
 
 func statNode(name string, modtime time.Time, permissions fs.FileMode,
 	ipldNode ipld.Node,

--- a/internal/filesystem/ipfsutil.go
+++ b/internal/filesystem/ipfsutil.go
@@ -9,40 +9,30 @@ import (
 	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format" // TODO: migrate to new standard
 	dag "github.com/ipfs/go-merkledag"
-	gopath "github.com/ipfs/go-path"
+	ipfspath "github.com/ipfs/go-path"
 	"github.com/ipfs/go-unixfs"
 	unixpb "github.com/ipfs/go-unixfs/pb"
 	corepath "github.com/ipfs/interface-go-ipfs-core/path"
 )
 
-func goToIPFSCore(fsid ID, goPath string) corepath.Path {
-	dbgErrPath := func(err error) corepath.Path {
-		// FIXME: sig needs to return errs
-		// TODO: debug path value; we should return this err instead.
-		return corepath.New(
-			path.Join("/",
-				goPath, err.Error(),
-			))
-	}
+func goToIPFSCore(fsid ID, goPath string) (corepath.Path, error) {
 	var (
-		pathComponents = strings.Split(goPath, "/")
-		cidStr         = pathComponents[0]
-		rootCID, err   = cid.Decode(cidStr)
+		namespace    = strings.ToLower(fsid.String()) // "ipfs", "ipns", ...
+		prefix       = path.Join("/", namespace)
+		components   = strings.Split(goPath, "/")
+		cidString    = components[0]
+		rootCID, err = cid.Decode(cidString)
 	)
 	if err != nil {
-		return dbgErrPath(err)
+		return nil, err
 	}
-	pathPrefix := path.Join("/",
-		strings.ToLower(fsid.String()), // "ipfs", "ipns", ...
+	var (
+		absoluteCID = path.Join(prefix, cidString)
+		cidPath     = ipfspath.Path(absoluteCID)
+		resolvedCID = corepath.NewResolvedPath(cidPath, rootCID, rootCID, "")
+		remainder   = components[1:]
 	)
-	return corepath.Join(corepath.NewResolvedPath(
-		gopath.Path(path.Join(
-			pathPrefix,
-			rootCID.String(),
-		)),
-		rootCID, rootCID, ""),
-		pathComponents[1:]...,
-	)
+	return corepath.Join(resolvedCID, remainder...), nil
 }
 
 func statNode(name string, modtime time.Time, permissions fs.FileMode,


### PR DESCRIPTION
The original (pre-emptive) intention was to avoid (potential) case-sensitive problems, stemming from a pin's CID.
While this is an okay idea, it's not our problem to solve, and doing so incurs a cost per-request.

Conversions should be left up to the node operator.
If a CID v0 does cause problems, they can upgrade it (once), and use the newer reference instead (removing the necessity of per-request conversions).

This also removes the maintenance need to keep up to date with external CID revisions (in this section of the code).

Extra:
This feature is also something we can add back in on-demand in an external program (like the file explorer shell extension), so that it only happens when it's actually desired.
But the only use case I can imagine for this is if someone wants to copy a reference to a v0 path, and assure it's compliant with non-case-preserving systems.
Seems unlikely, but it shouldn't be a hard problem to deal with later if it does come up.
We'd just use the same logic. Receive a path string, find the CID, convert and replace it, return the new reference.